### PR TITLE
+ Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Makefile
 cmake_install.cmake
 .cache
 tests/*.png
+result

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ cmake_install.cmake
 .cache
 tests/*.png
 result
+.direnv

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ CMakeCache.txt
 Makefile
 cmake_install.cmake
 .cache
+tests/*.png

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ CMakeFiles
 CMakeCache.txt
 Makefile
 cmake_install.cmake
+.cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,12 @@ AnsiLove/C keeps the CLI in `src/` (`ansilove.c`, `sauce.c`, helpers such as `st
 ## Build, Test, and Development Commands
 Configure once with `cmake -S . -B build [-DENABLE_SECCOMP=1]` to create a dedicated build tree. Compile via `cmake --build build`, which links against the system-provided `libansilove`. Run the binary locally with `build/ansilove foo.ans` to spot option regressions quickly. Exercise the suite using `ctest --test-dir build --output-on-failure`, covering ANSI, Artworx, BIN, PCBoard, Tundra, XBin, retina scaling, and SAUCE parsing.
 
+### Nix workflow
+- `nix develop` drops into a shell that wires `CMAKE_PREFIX_PATH`, `CMAKE_LIBRARY_PATH`, and `PKG_CONFIG_PATH` so CMake can find `libansilove`, `gd`, `libpng`, and `zlib` without Homebrew.
+- `nix run . -- -h` (or `nix run github:effect-native/ansilove -- -h`) uses the flake-provided package/app and skips manual builds.
+- `nix build .#default` produces the CLI in `./result/bin/ansilove`; git ignores `result`, `.cache`, `.direnv`, and the test PNGs.
+- `nix flake check --all-systems` succeeds after adding meta for the app; run it when touching the flake.
+
 ## Coding Style & Naming Conventions
 Stick to C99 and mirror the existing tab-based indentation with 80-column discipline. Functions use lower_snake_case, macros and constants stay in SCREAMING_SNAKE_CASE, and typedefs are declared in `types.h`. Keep include blocks grouped logically, prefer standard functions before adding compat variants, and respect the warning flags already set in `CMakeLists.txt`. Favor small, focused patches so reviewers can validate logic against the pedantic build.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+AnsiLove/C keeps the CLI in `src/` (`ansilove.c`, `sauce.c`, helpers such as `strtolower.c`). Portable fallbacks sit in `compat/` and are pulled in by `CMakeLists.txt` when the host lacks pledge or strtonum. Test fixtures for the regression suite live in `tests/`, and user-facing docs live in `man/`, `examples/`, and `ChangeLog`. Add new sources next to their headers and register them in `CMakeLists.txt` so every build configuration picks them up.
+
+## Build, Test, and Development Commands
+Configure once with `cmake -S . -B build [-DENABLE_SECCOMP=1]` to create a dedicated build tree. Compile via `cmake --build build`, which links against the system-provided `libansilove`. Run the binary locally with `build/ansilove foo.ans` to spot option regressions quickly. Exercise the suite using `ctest --test-dir build --output-on-failure`, covering ANSI, Artworx, BIN, PCBoard, Tundra, XBin, retina scaling, and SAUCE parsing.
+
+## Coding Style & Naming Conventions
+Stick to C99 and mirror the existing tab-based indentation with 80-column discipline. Functions use lower_snake_case, macros and constants stay in SCREAMING_SNAKE_CASE, and typedefs are declared in `types.h`. Keep include blocks grouped logically, prefer standard functions before adding compat variants, and respect the warning flags already set in `CMakeLists.txt`. Favor small, focused patches so reviewers can validate logic against the pedantic build.
+
+## Testing Guidelines
+New behavior should be covered by extending `add_test` entries in `CMakeLists.txt` with fixtures under `tests/`. When touching rendering paths, update or duplicate the bs-alove samples so `ctest` observes the change. Validate metadata work with `ansilove -s tests/sauce.txt` and ensure stdout noise is controlled via the `-q` flag. Document any manual image comparisons in the PR description when automation cannot assert the result.
+
+## Commit & Pull Request Guidelines
+Commits follow short, sentence-cased summaries ending with a period (see `git log`). Reference related issues or upstream discussions in the message body when context is useful. PRs should outline what changed, why it matters, and how you verified it (e.g., `ctest`, sample renders). Attach screenshots only when visual diffs are essential, and call out dependency or security toggles like seccomp in both the description and release notes draft.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758035966,
+        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,15 +15,36 @@
         gd = pkgs.gd;
         libs = map lib.getLib [ libansilove gd pkgs.libpng pkgs.zlib ];
         devs = map lib.getDev [ libansilove gd pkgs.libpng pkgs.zlib ];
-      in {
+        cmakeTools = with pkgs; [
+          cmake
+          ninja
+          pkg-config
+          clang
+          clang-tools
+        ];
+      in rec {
+        packages = rec {
+          ansilove = pkgs.stdenv.mkDerivation {
+            pname = "ansilove";
+            version = self.shortRev or "dev";
+            src = self;
+
+            nativeBuildInputs = cmakeTools;
+            buildInputs = devs ++ libs;
+
+            cmakeFlags = [ "-DENABLE_SECCOMP=0" ];
+          };
+
+          default = ansilove;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${packages.default}/bin/ansilove";
+        };
+
         devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [
-            cmake
-            ninja
-            pkg-config
-            clang
-            clang-tools
-          ];
+          nativeBuildInputs = cmakeTools;
           buildInputs = devs ++ libs;
           CMAKE_PREFIX_PATH = lib.makeSearchPath "" devs;
           CMAKE_LIBRARY_PATH = lib.makeSearchPath "lib" libs;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "AnsiLove/C development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        inherit (pkgs) lib;
+        libansilove = pkgs.libansilove;
+        libansiloveDev = libansilove.dev or libansilove;
+        gd = pkgs.gd;
+        gdDev = gd.dev or gd;
+        prefixInputs = [ libansiloveDev gdDev pkgs.zlib.dev pkgs.libpng.dev ];
+        pkgConfigInputs = [ libansiloveDev gdDev pkgs.libpng.dev pkgs.zlib.dev ];
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            cmake
+            ninja
+            pkg-config
+            clang
+            clang-tools
+            libansilove
+            gd
+            zlib
+            libpng
+          ];
+
+          shellHook = ''
+            export CMAKE_PREFIX_PATH="${lib.makeSearchPath "" prefixInputs}${CMAKE_PREFIX_PATH:+:}$CMAKE_PREFIX_PATH"
+            export PKG_CONFIG_PATH="${lib.makeSearchPath "lib/pkgconfig" pkgConfigInputs}${PKG_CONFIG_PATH:+:}$PKG_CONFIG_PATH"
+          '';
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,14 @@
             buildInputs = devs ++ libs;
 
             cmakeFlags = [ "-DENABLE_SECCOMP=0" ];
+
+            meta = with lib; {
+              description = "ANSI and ASCII art to PNG converter";
+              homepage = "https://www.ansilove.org";
+              license = licenses.bsd2;
+              mainProgram = "ansilove";
+              platforms = platforms.unix;
+            };
           };
 
           default = ansilove;
@@ -41,6 +49,7 @@
         apps.default = {
           type = "app";
           program = "${packages.default}/bin/ansilove";
+          meta = packages.default.meta;
         };
 
         devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -12,29 +12,22 @@
         pkgs = import nixpkgs { inherit system; };
         inherit (pkgs) lib;
         libansilove = pkgs.libansilove;
-        libansiloveDev = libansilove.dev or libansilove;
         gd = pkgs.gd;
-        gdDev = gd.dev or gd;
-        prefixInputs = [ libansiloveDev gdDev pkgs.zlib.dev pkgs.libpng.dev ];
-        pkgConfigInputs = [ libansiloveDev gdDev pkgs.libpng.dev pkgs.zlib.dev ];
+        libs = map lib.getLib [ libansilove gd pkgs.libpng pkgs.zlib ];
+        devs = map lib.getDev [ libansilove gd pkgs.libpng pkgs.zlib ];
       in {
         devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
+          nativeBuildInputs = with pkgs; [
             cmake
             ninja
             pkg-config
             clang
             clang-tools
-            libansilove
-            gd
-            zlib
-            libpng
           ];
-
-          shellHook = ''
-            export CMAKE_PREFIX_PATH="${lib.makeSearchPath "" prefixInputs}${CMAKE_PREFIX_PATH:+:}$CMAKE_PREFIX_PATH"
-            export PKG_CONFIG_PATH="${lib.makeSearchPath "lib/pkgconfig" pkgConfigInputs}${PKG_CONFIG_PATH:+:}$PKG_CONFIG_PATH"
-          '';
+          buildInputs = devs ++ libs;
+          CMAKE_PREFIX_PATH = lib.makeSearchPath "" devs;
+          CMAKE_LIBRARY_PATH = lib.makeSearchPath "lib" libs;
+          PKG_CONFIG_PATH = lib.makeSearchPath "lib/pkgconfig" devs;
         };
       });
 }


### PR DESCRIPTION
EDIT: also allows running ansilove without installing it first via nix like this:

```sh
nix run 'github:effect-native/ansilove?ref=nix-flake' -- -h
```

and if you accept this PR then also:

```sh
nix run github:ansilove/ansilove -- -h
```

# Summary
- add a reproducible `nix develop` shell that carries the right libs and toolchain with zero system deps.
- expose `nix run` / `nix build` entry points so downstreams (or CI) can fetch and execute the CLI without cloning or manual CMake steps.
- document the workflow in `AGENTS.md` so future contributors know how to use the flake.

# Why it matters
- ensures everyone, including CI, has the same headers/libraries: no more "missing libansilove/gd" configure failures.
- speeds up onboarding; `nix develop` replaces manual brewing of dependencies.
- keeps binary artifacts out of the tree: `.cache`, `.direnv`, `result`, and test PNGs are ignored.
- enabling `nix run github:effect-native/ansilove -h` makes distribution trivial for users and web demos.
- flakes unlock cross-platform checks (`nix flake check --all-systems`) so regressions on Linux/macOS get caught early.

# Testing
- `nix flake check --all-systems`
- `nix develop .#default --command bash -lc 'cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure'`
- `nix build .#default`
- `nix run . -- -h`
